### PR TITLE
Update gaussian_cantours.jl

### DIFF
--- a/kalman/gaussian_contours.jl
+++ b/kalman/gaussian_contours.jl
@@ -6,7 +6,7 @@ Plots of bivariate Gaussians to illustrate the Kalman filter.
 using PyPlot
 
 # Quick meshgrid function
-meshgrid(x::LinSpace, y::LinSpace) = (repmat(x, 1, length(y))',
+meshgrid(x::AbstractVector, y::AbstractVector) = (repmat(x, 1, length(y))',
                                   repmat(y, 1, length(x)))
 
 # bivariate normal function. I could call plt.mlab, but this is more fun!

--- a/kalman/gaussian_contours.jl
+++ b/kalman/gaussian_contours.jl
@@ -6,7 +6,7 @@ Plots of bivariate Gaussians to illustrate the Kalman filter.
 using PyPlot
 
 # Quick meshgrid function
-meshgrid(x::Vector, y::Vector) = (repmat(x, 1, length(y))',
+meshgrid(x::LinSpace, y::LinSpace) = (repmat(x, 1, length(y))',
                                   repmat(y, 1, length(x)))
 
 # bivariate normal function. I could call plt.mlab, but this is more fun!


### PR DESCRIPTION
When I run this code, there is 
LoadError: MethodError: meshgrid has no method matching meshgrid(::LinSpace{Float64}, ::LinSpace{Float64}).

The problem might be derived from line 9 " Quick meshgrid function " : 
"
meshgrid(x::Vector, y::Vector) = (repmat(x, 1, length(y))',
repmat(y, 1, length(x)))
"
which is not consistent with 
"
x_grid = linspace(-1.5, 2.9, 100)
y_grid = linspace(-3.1, 1.7, 100)
X, Y = meshgrid(x_grid, y_grid) .
"
Thus, regarding defining "meshgrid function", this one

meshgrid(x::AbstractVector, y::AbstractVector) = (repmat(x, 1, length(y))',
repmat(y, 1, length(x)))
works.
